### PR TITLE
Fix nonstring arguments

### DIFF
--- a/lib/smsglobal.rb
+++ b/lib/smsglobal.rb
@@ -60,7 +60,7 @@ module SmsGlobal
     def get(params = nil)
       url = URI.join(@base, 'http-api.php')
       if params
-        url.query = params.map { |k,v| "%s=%s" % [URI.encode(k.to_s), URI.encode(v)] }.join("&")
+        url.query = params.map { |k,v| "%s=%s" % [URI.encode(k.to_s), URI.encode(v.to_s)] }.join("&")
       end
       res = HTTP.start(url.host, url.port) do |http|
         http.get(url.request_uri)

--- a/spec/smsglobal_spec.rb
+++ b/spec/smsglobal_spec.rb
@@ -38,5 +38,18 @@ describe 'SmsGlobal' do
       resp[:status].should == :failed
       resp[:message].should == "Unable to reach SMSGlobal"
     end
+
+    context 'with non string values' do
+      before do
+        @sender = Sender.new :user => 'DUMMY', :password => 12345
+      end
+      it 'should not fail' do
+        stub_sms_ok
+        resp = @sender.send_text(1, 12341324, 1234)
+        resp[:status].should == :ok
+        resp[:code].should == 0
+        resp[:message].should == 'Sent queued message ID: 941596d028699601'
+      end
+    end
   end
 end


### PR DESCRIPTION
Sometimes, non strings get passed in; but URI encoding hates that.
